### PR TITLE
Allow static headers for OTLP exporter

### DIFF
--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
@@ -14,10 +14,11 @@ object OpenTelemetryOtlpGrpcSpanCompleter {
     host: String = "localhost",
     port: Int = 4317,
     config: CompleterConfig = CompleterConfig(),
-    protocol: String = "http"
+    protocol: String = "http",
+    staticHeaders: Map[String, String] = Map.empty,
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
-      OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port, protocol)
+      OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port, protocol, staticHeaders)
         .flatMap(QueuedSpanCompleter[F](process, _, config))
     }
 }

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
@@ -5,6 +5,7 @@ import fs2.Chunk
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, QueuedSpanCompleter}
 import io.janstenpickle.trace4cats.kernel.SpanCompleter
 import io.janstenpickle.trace4cats.model.TraceProcess
+import org.typelevel.ci.CIString
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -15,7 +16,7 @@ object OpenTelemetryOtlpGrpcSpanCompleter {
     port: Int = 4317,
     config: CompleterConfig = CompleterConfig(),
     protocol: String = "http",
-    staticHeaders: Map[String, String] = Map.empty,
+    staticHeaders: Map[CIString, String] = Map.empty,
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
       OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port, protocol, staticHeaders)

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
@@ -5,20 +5,21 @@ import cats.effect.kernel.{Async, Resource}
 import io.janstenpickle.trace4cats.kernel.SpanExporter
 import io.janstenpickle.trace4cats.opentelemetry.common.{Endpoint, OpenTelemetryGrpcSpanExporter}
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import org.typelevel.ci.CIString
 
 object OpenTelemetryOtlpGrpcSpanExporter {
   def apply[F[_]: Async, G[_]: Foldable](
     host: String = "localhost",
     port: Int = 4317,
     protocol: String = "http",
-    staticHeaders: Map[String, String] = Map.empty,
+    staticHeaders: Map[CIString, String] = Map.empty,
   ): Resource[F, SpanExporter[F, G]] =
     OpenTelemetryGrpcSpanExporter(
       endpoint = Endpoint(protocol, host, port),
       makeExporter = endpoint =>
         staticHeaders
           .foldLeft(OtlpGrpcSpanExporter.builder().setEndpoint(endpoint.render)) { case (builder, (key, value)) =>
-            builder.addHeader(key, value)
+            builder.addHeader(key.toString, value)
           }
           .build(),
     )


### PR DESCRIPTION
* A new parameter is added which can be used to specify static headers to be included in the HTTP requests
* Defaults to an empty map