### PR TITLE
Add/refactor static headers in OTLP exporters

### DIFF
--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
@@ -16,7 +16,7 @@ object OpenTelemetryOtlpGrpcSpanCompleter {
     port: Int = 4317,
     config: CompleterConfig = CompleterConfig(),
     protocol: String = "http",
-    staticHeaders: Map[CIString, String] = Map.empty,
+    staticHeaders: List[(CIString, String)] = List.empty
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
       OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port, protocol, staticHeaders)

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
@@ -12,7 +12,7 @@ object OpenTelemetryOtlpGrpcSpanExporter {
     host: String = "localhost",
     port: Int = 4317,
     protocol: String = "http",
-    staticHeaders: Map[CIString, String] = Map.empty,
+    staticHeaders: List[(CIString, String)] = List.empty
   ): Resource[F, SpanExporter[F, G]] =
     OpenTelemetryGrpcSpanExporter(
       endpoint = Endpoint(protocol, host, port),

--- a/modules/opentelemetry-otlp-http-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/main/scala/io/janstenpickle/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpHttpSpanCompleter.scala
@@ -5,7 +5,7 @@ import fs2.Chunk
 import io.janstenpickle.trace4cats.`export`.{CompleterConfig, QueuedSpanCompleter}
 import io.janstenpickle.trace4cats.kernel.SpanCompleter
 import io.janstenpickle.trace4cats.model.TraceProcess
-import org.http4s.Uri
+import org.http4s.{Header, Uri}
 import org.http4s.client.Client
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -18,21 +18,36 @@ object OpenTelemetryOtlpHttpSpanCompleter {
     host: String = "localhost",
     port: Int = 4318,
     config: CompleterConfig = CompleterConfig(),
-    protocol: String = "http"
+    protocol: String = "http",
+    staticHeaders: List[Header.ToRaw] = List.empty
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
       Resource
-        .eval(OpenTelemetryOtlpHttpSpanExporter[F, Chunk](client, host, port, protocol))
+        .eval(OpenTelemetryOtlpHttpSpanExporter[F, Chunk](client, host, port, protocol, staticHeaders))
         .flatMap(QueuedSpanCompleter[F](process, _, config))
     }
 
+  def fromUri[F[_]: Async](
+    client: Client[F],
+    process: TraceProcess,
+    uri: Uri,
+    config: CompleterConfig,
+    staticHeaders: List[Header.ToRaw] = List.empty
+  ): Resource[F, SpanCompleter[F]] =
+    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
+      QueuedSpanCompleter[F](
+        process,
+        OpenTelemetryOtlpHttpSpanExporter.fromUri[F, Chunk](client, uri, staticHeaders),
+        config
+      )
+    }
+
+  @deprecated("Use fromUri", since = "0.13.1")
   def apply[F[_]: Async](
     client: Client[F],
     process: TraceProcess,
     uri: Uri,
     config: CompleterConfig
   ): Resource[F, SpanCompleter[F]] =
-    Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
-      QueuedSpanCompleter[F](process, OpenTelemetryOtlpHttpSpanExporter[F, Chunk](client, uri), config)
-    }
+    fromUri[F](client, process, uri, config)
 }


### PR DESCRIPTION
Make `staticHeaders` parameter consistent across OTLP exporters.

Had to rename some factory methods due to "multiple overloaded alternatives of method apply define default arguments" compilation error.