### PR TITLE
Send TraceProcess attributes on resource

### DIFF
--- a/modules/opentelemetry-common/src/main/scala/trace4cats/opentelemetry/common/Trace4CatsResource.scala
+++ b/modules/opentelemetry-common/src/main/scala/trace4cats/opentelemetry/common/Trace4CatsResource.scala
@@ -1,9 +1,9 @@
 package trace4cats.opentelemetry.common
 
-import io.opentelemetry.api.common.{AttributeKey, Attributes}
 import io.opentelemetry.sdk.resources.Resource
+import trace4cats.AttributeValue
 
 object Trace4CatsResource {
-  def apply(serviceName: String): Resource =
-    Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), serviceName))
+  def apply(serviceName: String, attributes: Map[String, AttributeValue]): Resource =
+    Resource.create(Trace4CatsAttributes(Map[String, AttributeValue]("service.name" -> serviceName) ++ attributes))
 }

--- a/modules/opentelemetry-jaeger-exporter/src/main/scala/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleter.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/main/scala/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanCompleter.scala
@@ -17,7 +17,7 @@ object OpenTelemetryJaegerSpanCompleter {
     protocol: String = "http"
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
-      OpenTelemetryJaegerSpanExporter[F, Chunk](host, port, protocol)
-        .flatMap(QueuedSpanCompleter[F](process, _, config))
+      OpenTelemetryJaegerSpanExporter[F, Chunk](host, port, protocol, process.attributes)
+        .flatMap(QueuedSpanCompleter[F](TraceProcess(process.serviceName), _, config))
     }
 }

--- a/modules/opentelemetry-jaeger-exporter/src/main/scala/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporter.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/main/scala/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporter.scala
@@ -3,6 +3,7 @@ package trace4cats.opentelemetry.jaeger
 import cats.Foldable
 import cats.effect.kernel.{Async, Resource}
 import io.opentelemetry.exporter.jaeger.JaegerGrpcSpanExporter
+import trace4cats.AttributeValue
 import trace4cats.kernel.SpanExporter
 import trace4cats.opentelemetry.common.{Endpoint, OpenTelemetryGrpcSpanExporter}
 
@@ -10,10 +11,12 @@ object OpenTelemetryJaegerSpanExporter {
   def apply[F[_]: Async, G[_]: Foldable](
     host: String = "localhost",
     port: Int = 14250,
-    protocol: String = "http"
+    protocol: String = "http",
+    resourceAttributes: Map[String, AttributeValue] = Map.empty
   ): Resource[F, SpanExporter[F, G]] =
     OpenTelemetryGrpcSpanExporter(
       Endpoint(protocol, host, port),
+      resourceAttributes,
       ep => JaegerGrpcSpanExporter.builder().setEndpoint(ep.render).build()
     )
 }

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporterSpec.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/trace4cats/opentelemetry/jaeger/OpenTelemetryJaegerSpanExporterSpec.scala
@@ -14,7 +14,7 @@ class OpenTelemetryJaegerSpanExporterSpec extends BaseJaegerSpec {
         batch.spans.map(span =>
           span.copy(
             serviceName = process.serviceName,
-            attributes = (process.attributes ++ span.allAttributes)
+            attributes = span.allAttributes
               .filterNot { case (key, _) =>
                 excludedTagKeys.contains(key)
               },
@@ -25,7 +25,7 @@ class OpenTelemetryJaegerSpanExporterSpec extends BaseJaegerSpec {
       )
 
     testExporter(
-      OpenTelemetryJaegerSpanExporter[IO, Chunk]("localhost", 14250),
+      OpenTelemetryJaegerSpanExporter[IO, Chunk]("localhost", 14250, "http", process.attributes),
       updatedBatch,
       batchToJaegerResponse(updatedBatch, process, kindTags, statusTags, processTags, additionalTags)
     )

--- a/modules/opentelemetry-jaeger-exporter/src/test/scala/trace4cats/opentelemetry/jaeger/package.scala
+++ b/modules/opentelemetry-jaeger-exporter/src/test/scala/trace4cats/opentelemetry/jaeger/package.scala
@@ -26,7 +26,8 @@ package object jaeger {
     attrs ++ errorAttrs
   }
 
-  val processTags: TraceProcess => Map[String, AttributeValue] = p => Map("service.name" -> p.serviceName)
+  val processTags: TraceProcess => Map[String, AttributeValue] = p =>
+    Map[String, AttributeValue]("service.name" -> p.serviceName) ++ p.attributes
 
   val additionalTags: Map[String, AttributeValue] =
     Map("otel.library.name" -> "trace4cats", "otel.scope.name" -> "trace4cats")

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanCompleter.scala
@@ -19,7 +19,7 @@ object OpenTelemetryOtlpGrpcSpanCompleter {
     staticHeaders: List[(CIString, String)] = List.empty
   ): Resource[F, SpanCompleter[F]] =
     Resource.eval(Slf4jLogger.create[F]).flatMap { implicit logger: Logger[F] =>
-      OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port, protocol, staticHeaders)
-        .flatMap(QueuedSpanCompleter[F](process, _, config))
+      OpenTelemetryOtlpGrpcSpanExporter[F, Chunk](host, port, protocol, staticHeaders, process.attributes)
+        .flatMap(QueuedSpanCompleter[F](TraceProcess(process.serviceName), _, config))
     }
 }

--- a/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
+++ b/modules/opentelemetry-otlp-grpc-exporter/src/main/scala/trace4cats/opentelemetry/otlp/OpenTelemetryOtlpGrpcSpanExporter.scala
@@ -4,6 +4,7 @@ import cats.Foldable
 import cats.effect.kernel.{Async, Resource}
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
 import org.typelevel.ci.CIString
+import trace4cats.AttributeValue
 import trace4cats.kernel.SpanExporter
 import trace4cats.opentelemetry.common.{Endpoint, OpenTelemetryGrpcSpanExporter}
 
@@ -12,10 +13,12 @@ object OpenTelemetryOtlpGrpcSpanExporter {
     host: String = "localhost",
     port: Int = 4317,
     protocol: String = "http",
-    staticHeaders: List[(CIString, String)] = List.empty
+    staticHeaders: List[(CIString, String)] = List.empty,
+    resourceAttributes: Map[String, AttributeValue] = Map.empty
   ): Resource[F, SpanExporter[F, G]] =
     OpenTelemetryGrpcSpanExporter(
       endpoint = Endpoint(protocol, host, port),
+      resourceAttributes,
       makeExporter = endpoint =>
         staticHeaders
           .foldLeft(OtlpGrpcSpanExporter.builder().setEndpoint(endpoint.render)) { case (builder, (key, value)) =>


### PR DESCRIPTION
OpenTelemetry allows setting attributes on the resource associated with each span to attach information about the resource creating those spans, and the spec also details some conventions for naming [1].

So far, this integration has only been sending the `service.name` attribute as the only value in resource attributes, but for some tracing solutions, it's important to be able to specify other attributes, such as the deployment environment (`deployment.environment`).

This moves the attributes associated with the `TraceProcess` from each individual span to the resource level, where they are more likely to belong.

Unfortunately not backwards compatible, and makes life harder for those who need to add attributes to every span (although it should be possible with a custom span completer).

_Disclaimer:_ I'm not to familiar with the `TraceProcess` abstraction and realize that these changes might not be hitting the nail on the head, but I'd be happy to implement this in another way if you have other suggestions.

[1] https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/