### PR TITLE
Adjust OTEL JSON format to breaking changes

### DIFF
--- a/.github/otel-test-config.yaml
+++ b/.github/otel-test-config.yaml
@@ -17,7 +17,7 @@ processors:
 
 exporters:
   logging:
-    logLevel: debug
+    verbosity: detailed
   jaeger:
     endpoint: jaeger:14250
     tls:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   otelcol:
-    image: otel/opentelemetry-collector:0.56.0
+    image: otel/opentelemetry-collector:0.74.0
     ports:
       - "4317:4317"
       - "4318:4318"
@@ -14,7 +14,7 @@ services:
       - jaeger
 
   jaeger:
-    image: jaegertracing/all-in-one:1.36.0
+    image: jaegertracing/all-in-one:1.44.0
     ports:
       - "5775:5775/udp"
       - "6831:6831/udp"

--- a/modules/opentelemetry-otlp-http-exporter/src/main/scala/trace4cats/opentelemetry/otlp/json/ResourceSpansBatch.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/main/scala/trace4cats/opentelemetry/otlp/json/ResourceSpansBatch.scala
@@ -72,12 +72,7 @@ object ResourceSpansBatch {
         .map { case (service, spans) =>
           ResourceSpans(
             resource = Resource(attributes = List(KeyValue("service.name", AnyValue.stringValue(service)))),
-            instrumentation_library_spans = List(
-              InstrumentationLibrarySpans(
-                instrumentation_library = InstrumentationLibrary("trace4cats"),
-                spans = spans.toList
-              )
-            )
+            scope_spans = List(ScopeSpans(scope = InstrumentationScope("trace4cats"), spans = spans.toList))
           )
         }
         .toList
@@ -89,7 +84,7 @@ object ResourceSpansBatch {
 
 case class ResourceSpansBatch(resource_spans: List[ResourceSpans])
 
-case class ResourceSpans(resource: Resource, instrumentation_library_spans: List[InstrumentationLibrarySpans])
+case class ResourceSpans(resource: Resource, scope_spans: List[ScopeSpans])
 object ResourceSpans {
   implicit val resourceSpansEncoder: Encoder.AsObject[ResourceSpans] = deriveEncoder
 }
@@ -99,14 +94,19 @@ object Resource {
   implicit val resourceEncoder: Encoder.AsObject[Resource] = deriveEncoder
 }
 
-case class InstrumentationLibrarySpans(instrumentation_library: InstrumentationLibrary, spans: List[Span])
-object InstrumentationLibrarySpans {
-  implicit val instrumentationLibrarySpansEncoder: Encoder.AsObject[InstrumentationLibrarySpans] = deriveEncoder
+case class ScopeSpans(scope: InstrumentationScope, spans: List[Span])
+object ScopeSpans {
+  implicit val scopeSpansEncoder: Encoder.AsObject[ScopeSpans] = deriveEncoder
 }
 
-case class InstrumentationLibrary(name: String, version: String = "")
-object InstrumentationLibrary {
-  implicit val instrumentationLibraryEncoder: Encoder.AsObject[InstrumentationLibrary] = deriveEncoder
+case class InstrumentationScope(
+  name: String,
+  version: String = "",
+  attributes: List[KeyValue] = Nil,
+  dropped_attributes_count: Int = 0
+)
+object InstrumentationScope {
+  implicit val instrumentationScopeEncoder: Encoder.AsObject[InstrumentationScope] = deriveEncoder
 }
 
 case class Status(message: String, code: Status.Code)


### PR DESCRIPTION
The OTEL trace format had [breaking changes](https://github.com/open-telemetry/opentelemetry-proto/blob/7aa439cb0ba78afbd009d83f32fdda6c128e0342/CHANGELOG.md?plain=1#L33-L37) a while back, so to work with up-to-date collectors and trace backends like Jaeger, it has to be adjusted.

Tested with OTEL collector 0.74 and a relatively recent Jaeger.