### PR TITLE
Preserve precise span timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master') && (github.actor != 'mergify[bot]')
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && (github.actor != 'mergify[bot]')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
     }
   },
   Test / fork := true,
-  resolvers += Resolver.sonatypeRepo("releases"),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
 )
 
 lazy val noPublishSettings =

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -20,7 +20,10 @@ ThisBuild / githubWorkflowBuildPostamble += WorkflowStep.Run(
   name = Some("Stop and remove Docker resources")
 )
 
-ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.Equals(Ref.Branch("master")))
+ThisBuild / githubWorkflowPublishTargetBranches := Seq(
+  RefPredicate.Equals(Ref.Branch("master")),
+  RefPredicate.StartsWith(Ref.Tag("v"))
+)
 ThisBuild / githubWorkflowPublish := Seq(
   WorkflowStep.Sbt(
     List("ciReleaseSonatype"),

--- a/modules/opentelemetry-common/src/main/scala/trace4cats/opentelemetry/common/Trace4CatsSpanData.scala
+++ b/modules/opentelemetry-common/src/main/scala/trace4cats/opentelemetry/common/Trace4CatsSpanData.scala
@@ -2,7 +2,6 @@ package trace4cats.opentelemetry.common
 
 import java.util
 import java.util.concurrent.TimeUnit
-
 import cats.syntax.show._
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.{SpanKind => OtelSpanKind, _}
@@ -13,6 +12,8 @@ import trace4cats.model.SpanStatus._
 import trace4cats.model.TraceState.{Key, Value}
 import trace4cats.model.{CompletedSpan, SampleDecision, SpanKind}
 
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
@@ -62,7 +63,7 @@ object Trace4CatsSpanData {
           case SpanKind.Consumer => OtelSpanKind.CONSUMER
         }
 
-      override lazy val getStartEpochNanos: Long = TimeUnit.MILLISECONDS.toNanos(span.start.toEpochMilli)
+      override lazy val getStartEpochNanos: Long = ChronoUnit.NANOS.between(Instant.EPOCH, span.start)
 
       override val getAttributes: Attributes = Trace4CatsAttributes(span.allAttributes)
 
@@ -84,7 +85,7 @@ object Trace4CatsSpanData {
           case _ => StatusData.error()
         }
 
-      override lazy val getEndEpochNanos: Long = TimeUnit.MILLISECONDS.toNanos(span.end.toEpochMilli)
+      override lazy val getEndEpochNanos: Long = ChronoUnit.NANOS.between(Instant.EPOCH, span.end)
 
       override lazy val getParentSpanContext: SpanContext =
         span.context.parent.fold(SpanContext.getInvalid) { p =>

--- a/modules/opentelemetry-common/src/main/scala/trace4cats/opentelemetry/common/Trace4CatsSpanData.scala
+++ b/modules/opentelemetry-common/src/main/scala/trace4cats/opentelemetry/common/Trace4CatsSpanData.scala
@@ -1,7 +1,6 @@
 package trace4cats.opentelemetry.common
 
 import java.util
-import java.util.concurrent.TimeUnit
 import cats.syntax.show._
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.{SpanKind => OtelSpanKind, _}

--- a/modules/opentelemetry-otlp-http-exporter/src/main/scala/trace4cats/opentelemetry/otlp/json/ResourceSpansBatch.scala
+++ b/modules/opentelemetry-otlp-http-exporter/src/main/scala/trace4cats/opentelemetry/otlp/json/ResourceSpansBatch.scala
@@ -1,6 +1,7 @@
 package trace4cats.opentelemetry.otlp.json
 
-import java.util.concurrent.TimeUnit
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 import cats.Foldable
 import cats.syntax.foldable._
@@ -45,8 +46,8 @@ object ResourceSpansBatch {
           case SpanKind.Producer => SPAN_KIND_PRODUCER
           case SpanKind.Consumer => SPAN_KIND_CONSUMER
         },
-        start_time_unix_nano = TimeUnit.MILLISECONDS.toNanos(span.start.toEpochMilli),
-        end_time_unix_nano = TimeUnit.MILLISECONDS.toNanos(span.end.toEpochMilli),
+        start_time_unix_nano = ChronoUnit.NANOS.between(Instant.EPOCH, span.start),
+        end_time_unix_nano = ChronoUnit.NANOS.between(Instant.EPOCH, span.end),
         attributes = toAttributes(span.allAttributes),
         status = Status(
           code = span.status match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.8"
     val scala3 = "3.3.0"
 
-    val trace4cats = "0.14.3"
+    val trace4cats = "0.14.4"
     val trace4catsExporterHttp = "0.14.0"
     val trace4catsJaegerIntegrationTest = "0.14.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
 
     val trace4cats = "0.14.3"
     val trace4catsExporterHttp = "0.14.0"
-    val trace4catsJaegerIntegrationTest = "0.14.1"
+    val trace4catsJaegerIntegrationTest = "0.14.2"
 
     val autoValue = "1.10.1"
     val circe = "0.14.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,9 +6,9 @@ object Dependencies {
     val scala213 = "2.13.8"
     val scala3 = "3.3.0"
 
-    val trace4cats = "0.14.0"
+    val trace4cats = "0.14.3"
     val trace4catsExporterHttp = "0.14.0"
-    val trace4catsJaegerIntegrationTest = "0.14.0"
+    val trace4catsJaegerIntegrationTest = "0.14.1"
 
     val autoValue = "1.10.1"
     val circe = "0.14.2"


### PR DESCRIPTION
Since cats-effect 3.4, the Instant we get can be more precise than just milliseconds, but so far, the conversions lose the micros and nanos.