### PR TITLE
Adjust field names of JSON output in compliance with OTLP/HTTP spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ local.*
 .bsp
 .java-version
 **/.DS_store
+
+.metals
+.bloop


### PR DESCRIPTION
[OTLP/HTTP spec](https://opentelemetry.io/docs/specs/otlp/#otlphttp) states that JSON field names should be lowerCamelCased.

See [JSON Protobuf Encoding](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding), in particular:

> The keys of JSON objects are field names converted to lowerCamelCase. Original field names are not valid to use as keys for JSON objects. For example, this is a valid JSON representation of a Resource: { "attributes": {...}, "droppedAttributesCount": 123 }, and this is NOT a valid representation: { "attributes": {...}, "dropped_attributes_count": 123 }.